### PR TITLE
feat: (#3) 클로바 ai를 통해 문제 생성 및 DB에 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	// external API + json
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/poten/backend/BackendApplication.java
+++ b/src/main/java/org/poten/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package org.poten.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/org/poten/backend/clova/controller/ClovaQuestionController.java
+++ b/src/main/java/org/poten/backend/clova/controller/ClovaQuestionController.java
@@ -1,0 +1,34 @@
+package org.poten.backend.clova.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.poten.backend.clova.dto.response.QuestionDto;
+import org.poten.backend.clova.service.ClovaQuestionService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.poten.backend.global.security.CustomUserDetails;
+import org.poten.backend.global.error.GlobalErrorCode;
+import org.poten.backend.global.exception.CustomException;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/clova")
+@RequiredArgsConstructor
+public class ClovaQuestionController {
+
+    private final ClovaQuestionService clovaQuestionService;
+
+    @PostMapping("/question")
+    public List<QuestionDto> generateAndSaveQuestion(@RequestBody Map<String, String> request, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if (customUserDetails == null) {
+            throw new CustomException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+        String plainText = request.get("plainText");
+        String type = request.get("type");
+        return clovaQuestionService.generateAndSaveQuestion(plainText, type, customUserDetails.getUser());
+    }
+}

--- a/src/main/java/org/poten/backend/clova/dto/request/ClovaRequest.java
+++ b/src/main/java/org/poten/backend/clova/dto/request/ClovaRequest.java
@@ -1,0 +1,24 @@
+package org.poten.backend.clova.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ClovaRequest {
+    private List<Message> messages;
+    private double topP = 0.8;
+    private int topK = 0;
+    private int maxTokens = 500;
+    private double temperature = 0.3;
+    private double repetitionPenalty = 1.1;
+    private List<String> stop = List.of();
+    private int seed = 0;
+    private boolean includeAiFilters = true;
+
+    public ClovaRequest(List<Message> messages) {
+        this.messages = messages;
+    }
+}

--- a/src/main/java/org/poten/backend/clova/dto/request/Content.java
+++ b/src/main/java/org/poten/backend/clova/dto/request/Content.java
@@ -1,0 +1,11 @@
+package org.poten.backend.clova.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Content {
+    private String type;
+    private String text;
+}

--- a/src/main/java/org/poten/backend/clova/dto/request/Message.java
+++ b/src/main/java/org/poten/backend/clova/dto/request/Message.java
@@ -1,0 +1,13 @@
+package org.poten.backend.clova.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private List<Content> content;
+}

--- a/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
+++ b/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
@@ -1,0 +1,16 @@
+package org.poten.backend.clova.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class QuestionDto {
+    private String question;
+    private String type;
+    private List<String> options;
+    private String answer;
+    private String explanation;
+}

--- a/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
+++ b/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
@@ -1,0 +1,156 @@
+package org.poten.backend.clova.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.poten.backend.clova.dto.request.ClovaRequest;
+import org.poten.backend.clova.dto.request.Content;
+import org.poten.backend.clova.dto.request.Message;
+import org.poten.backend.clova.dto.response.QuestionDto;
+import org.poten.backend.global.infra.clova.ClovaProperty;
+import org.poten.backend.global.infra.clova.OkHttpJsonRequest;
+import org.poten.backend.question.repository.QuestionRepository;
+import org.poten.backend.question.entity.Question;
+import org.poten.backend.user.entity.User;
+import org.poten.backend.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.HttpStatus;
+import lombok.Getter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.poten.backend.global.infra.clova.OkHttpRequest.createRequest;
+import org.poten.backend.global.error.ErrorCode;
+import org.poten.backend.global.exception.CustomException;
+
+@Service
+@RequiredArgsConstructor
+public class ClovaQuestionService {
+
+    private final ClovaProperty clovaProperty;
+    private final ObjectMapper objectMapper;
+    private final QuestionRepository questionRepository;
+
+    @Transactional
+    public List<QuestionDto> generateAndSaveQuestion(String plainText, String type, User user) {
+        String requestBody = createClovaRequestBody(plainText, type);
+
+        Request request = new Request.Builder()
+                .url(clovaProperty.getUrl())
+                .header("Authorization", "Bearer " + clovaProperty.getKey())
+                .header("X-NCP-CLOVASTUDIO-REQUEST-ID", clovaProperty.getId())
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .post(RequestBody.create(requestBody, MediaType.parse("application/json")))
+                .build();
+
+        try (Response response = createRequest(request)) {
+            if (!response.isSuccessful()) {
+                throw new IOException("Unexpected code " + response);
+            }
+            if (response.body() == null) {
+                throw new IOException("Response body is null");
+            }
+            String responseBody = response.body().string();
+
+            com.fasterxml.jackson.databind.JsonNode rootNode = objectMapper.readTree(responseBody);
+            String content = rootNode.path("result").path("message").path("content").asText();
+            String jsonContent = content.substring(content.indexOf("["), content.lastIndexOf("]") + 1);
+
+            List<QuestionDto> questionDtos = objectMapper.readValue(jsonContent, new com.fasterxml.jackson.core.type.TypeReference<List<QuestionDto>>() {});
+
+            saveQuestions(questionDtos, user);
+
+            return questionDtos;
+        } catch (IOException e) {
+            throw new ClovaQuestionServiceException(ClovaQuestionServiceErrorCode.CLOVA_API_ERROR);
+        }
+    }
+
+    private void saveQuestions(List<QuestionDto> questionDtos, User user) {
+        List<Question> questions = questionDtos.stream()
+                .map(questionDto -> Question.builder()
+                        .questionText(questionDto.getQuestion())
+                        .answer(questionDto.getAnswer())
+                        .questionType(questionDto.getType())
+                        .explanation(questionDto.getExplanation())
+                        .user(user)
+                        .build())
+                .collect(Collectors.toList());
+        questionRepository.saveAll(questions);
+    }
+
+    private String createClovaRequestBody(String plainText, String type) {
+        Message systemMessage = new Message("system", List.of(new Content("text", getSystemContent())));
+        Message userMessage = new Message("user", List.of(new Content("text", "<입력으로 들어온 정리> " + plainText + " 문제 유형: <" + type + ">")));
+        ClovaRequest clovaRequest = new ClovaRequest(List.of(systemMessage, userMessage));
+        return new OkHttpJsonRequest(clovaRequest).convertRequestToString();
+    }
+
+    private String getSystemContent() {
+        return """
+        [역할]
+        너는 사용자가 정리한 내용을 바탕으로만 문제를 생성하는 AI야.
+        지식 창작, 일반 상식, 부정확한 내용 추가는 절대 하지 마.
+
+        [규칙]
+        - 문제는 반드시 입력 내용 안에서만 만들 것
+        - 문제 유형은 반드시 다음 중 하나로만 제한할 것: MULTIPLE_CHOICE, SHORT_ANSWER, TRUE_FALSE
+        - 무조건 3개의 문제만 생성할 것
+        - 텍스트 지문에 포함되지 않은 내용은 퀴즈로 출제하지 않습니다.
+        - 모든 문제는 아래 구조와 동일한 JSON 형식으로 반환할 것
+        - 모든 문제 유형에서 다음 키 값을 항상 포함해야 함:
+          `question`, `type`, `options`, `answer`, `explanation`
+
+        객관식(MULTIPLE_CHOICE)
+        - `options`는 반드시 4개의 보기 항목 포함
+        - `answer`는 `options` 중 하나여야 함
+
+        단답형(SHORT_ANSWER) 또는 OX(TRUE_FALSE)
+        - `options`는 빈 배열 `[]`
+        - `answer`는 간결한 문자열
+        - `TRUE_FALSE`는 "TRUE" 또는 "FALSE"만 허용
+
+        모든 문제에는 `explanation` 필드를 포함
+        - 사용자가 정답을 이해할 수 있도록, AI가 간단히 핵심 개념을 요약하거나 정답의 이유를 1문장으로 설명
+        - 입력 내용 기반이어야 하며, 과도한 추측이나 새로운 지식 창작은 지양
+
+        ---
+
+        [출력 예시]
+        ```json
+        [
+          {
+            "question": "HTTP는 상태를 저장하지 않는 프로토콜이다.",
+            "type": "TRUE_FALSE",
+            "options": [],
+            "answer": "TRUE",
+            "explanation": "HTTP는 무상태(stateless) 프로토콜로, 각 요청은 독립적으로 처리된다."
+          }
+        ]
+        ```
+        """;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ClovaQuestionServiceErrorCode implements ErrorCode {
+        CLOVA_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CS001", "클로바 API 연동 중 오류가 발생했습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+    }
+
+    public static class ClovaQuestionServiceException extends CustomException {
+        public ClovaQuestionServiceException(ErrorCode errorCode) {
+            super(errorCode);
+        }
+    }
+}

--- a/src/main/java/org/poten/backend/global/exception/OkhttpException.java
+++ b/src/main/java/org/poten/backend/global/exception/OkhttpException.java
@@ -1,0 +1,11 @@
+package org.poten.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OkhttpException extends RuntimeException {
+
+    public OkhttpException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/poten/backend/global/infra/clova/ClovaProperty.java
+++ b/src/main/java/org/poten/backend/global/infra/clova/ClovaProperty.java
@@ -1,0 +1,16 @@
+package org.poten.backend.global.infra.clova;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties("clova.api")
+public class ClovaProperty {
+    private String url;
+    private String key;
+    private String id;
+}

--- a/src/main/java/org/poten/backend/global/infra/clova/OkHttpJsonRequest.java
+++ b/src/main/java/org/poten/backend/global/infra/clova/OkHttpJsonRequest.java
@@ -1,0 +1,23 @@
+package org.poten.backend.global.infra.clova;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class OkHttpJsonRequest extends OkHttpRequest {
+
+    private final Object request;
+
+    public OkHttpJsonRequest(Object request) {
+        this.request = request;
+    }
+
+    @Override
+    public String convertRequestToString() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.writeValueAsString(this.request);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/poten/backend/global/infra/clova/OkHttpRequest.java
+++ b/src/main/java/org/poten/backend/global/infra/clova/OkHttpRequest.java
@@ -1,0 +1,53 @@
+package org.poten.backend.global.infra.clova;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.poten.backend.global.exception.OkhttpException;
+
+import java.io.IOException;
+
+@Slf4j
+public abstract class OkHttpRequest {
+
+    private static final OkHttpClient client = new OkHttpClient();
+
+    public static Response createRequest(Request request) {
+        StringBuilder logStringBuilder = new StringBuilder();
+        Response response;
+        try {
+            response = client.newCall(request)
+                .execute();
+        } catch (IOException e) {
+            logStringBuilder.append("[Okhttp Request Fail]");
+            logStringBuilder.append("Request Url : ");
+            logStringBuilder.append(request.url());
+            logStringBuilder.append(" Request Body : ");
+            logStringBuilder.append(requestBodyToString(request));
+            log.error(logStringBuilder.toString());
+            throw new OkhttpException(e.getMessage());
+        }
+        return response;
+    }
+
+    private static String requestBodyToString(Request request) {
+        try {
+            final Request copy = request.newBuilder().build();
+            final okio.Buffer buffer = new okio.Buffer();
+            RequestBody body = copy.body();
+            if (body != null) {
+                body.writeTo(buffer);
+                return buffer.readUtf8();
+            }
+            return "";
+        } catch (final IOException e) {
+            return "did not work";
+        }
+    }
+
+    protected abstract String convertRequestToString();
+}

--- a/src/main/java/org/poten/backend/question/repository/QuestionRepository.java
+++ b/src/main/java/org/poten/backend/question/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package org.poten.backend.question.repository;
+
+import org.poten.backend.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
@@ -1,0 +1,7 @@
+package org.poten.backend.question.repository;
+
+import org.poten.backend.question.entity.SolveHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #3 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

1. 요청 값(사용자의 정리 데이터, 문제 유형)으로 클로바 api를 통해 문제 생성
2. DB에 생성된 데이터 저장

## #️⃣ 테스트 결과

1. 로그인 인증 유저만 사용가능하며 DB에 저장되는 것 까지 확인하였습니다.


## #️⃣ 스크린샷 (선택)

<img width="773" height="673" alt="image" src="https://github.com/user-attachments/assets/1c22d769-28d0-4049-bada-866ffc603909" />




## 📎 참고 자료 (선택)

1. application.yml파일의 변화가 있습니다. (노션 참고)
2. 로그인 유저만 사용가능하고 현재는 3문제씩 생성하도록 하였습니다. (문제를 늘릴경우 프롬프트 수정 or api 요청 파라미터에 문제 생성 수를 입력으로 받아야 합니다)