### PR TITLE
Feat/(#7) 유저의 날짜별 제작한 문제를 조회 

### DIFF
--- a/src/main/java/org/poten/backend/question/controller/QuestionController.java
+++ b/src/main/java/org/poten/backend/question/controller/QuestionController.java
@@ -1,0 +1,31 @@
+package org.poten.backend.question.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.poten.backend.global.error.GlobalErrorCode;
+import org.poten.backend.global.exception.CustomException;
+import org.poten.backend.question.dto.response.QuestionListResponse;
+import org.poten.backend.question.service.QuestionService;
+import org.poten.backend.global.security.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/question")
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping
+    public ResponseEntity<List<QuestionListResponse>> findAllQuestion(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        if (customUserDetails == null) {
+            throw new CustomException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+        return ResponseEntity.ok(questionService.findAllQuestion(customUserDetails.getUser()));
+    }
+}

--- a/src/main/java/org/poten/backend/question/dto/response/QuestionListResponse.java
+++ b/src/main/java/org/poten/backend/question/dto/response/QuestionListResponse.java
@@ -1,0 +1,18 @@
+package org.poten.backend.question.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionListResponse {
+    private LocalDate date;
+    private List<QuestionResponse> questions;
+}

--- a/src/main/java/org/poten/backend/question/dto/response/QuestionResponse.java
+++ b/src/main/java/org/poten/backend/question/dto/response/QuestionResponse.java
@@ -1,0 +1,27 @@
+package org.poten.backend.question.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.poten.backend.question.entity.Question;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionResponse {
+    private String questionText;
+    private String answer;
+    private String questionType;
+    private String explanation;
+
+    public static QuestionResponse from(Question question) {
+        return QuestionResponse.builder()
+                .questionText(question.getQuestionText())
+                .answer(question.getAnswer())
+                .questionType(question.getQuestionType())
+                .explanation(question.getExplanation())
+                .build();
+    }
+}

--- a/src/main/java/org/poten/backend/question/repository/QuestionRepository.java
+++ b/src/main/java/org/poten/backend/question/repository/QuestionRepository.java
@@ -1,7 +1,11 @@
 package org.poten.backend.question.repository;
 
 import org.poten.backend.question.entity.Question;
+import org.poten.backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> findByUser(User user);
 }

--- a/src/main/java/org/poten/backend/question/service/QuestionService.java
+++ b/src/main/java/org/poten/backend/question/service/QuestionService.java
@@ -1,0 +1,50 @@
+package org.poten.backend.question.service;
+
+import org.poten.backend.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.poten.backend.global.error.GlobalErrorCode;
+import org.poten.backend.global.exception.CustomException;
+import org.poten.backend.global.exception.CustomException;
+import org.poten.backend.question.dto.response.QuestionListResponse;
+import org.poten.backend.question.dto.response.QuestionResponse;
+import org.poten.backend.question.entity.Question;
+import org.poten.backend.question.repository.QuestionRepository;
+import org.poten.backend.user.entity.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    public List<QuestionListResponse> findAllQuestion(User user) {
+        if (user == null) {
+            throw new CustomException(GlobalErrorCode.USER_NOT_FOUND);
+        }
+
+        List<Question> questions = questionRepository.findByUser(user);
+
+        Map<LocalDate, List<QuestionResponse>> groupedByDate = questions.stream()
+                .collect(Collectors.groupingBy(
+                        question -> question.getCreatedAt().toLocalDate(),
+                        Collectors.mapping(QuestionResponse::from, Collectors.toList())
+                ));
+
+        return groupedByDate.entrySet().stream()
+                .map(entry -> QuestionListResponse.builder()
+                        .date(entry.getKey())
+                        .questions(entry.getValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: Closes #7 (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

1. 이전까지 제작한 문제를 조회 할 수 있는 기능 (로그인한 유저가 본인의 문제만 조회 가능)
2. 페이지가 어떤식으로 구현 될 지 몰라서 일단 페이지 네이션 없이 모든 날짜 별 모든 데이터를 불러왔습니다.


## #️⃣ 테스트 결과
1. 로그인한 유저의 문제를 날짜별로 조회되는 것을 확인하였습니다.


## #️⃣ 스크린샷 (선택)

<img width="741" height="675" alt="스크린샷 2025-08-03 오후 9 33 39" src="https://github.com/user-attachments/assets/45bed489-de43-471a-96fe-3185d1f28bc4" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요