### PR TITLE
Feat/#13 비로그인 상태에서도 문제 생성, 로그인 상태에서 10문제 생성하도록 변경

### DIFF
--- a/src/main/java/org/poten/backend/clova/controller/ClovaQuestionController.java
+++ b/src/main/java/org/poten/backend/clova/controller/ClovaQuestionController.java
@@ -3,14 +3,14 @@ package org.poten.backend.clova.controller;
 import lombok.RequiredArgsConstructor;
 import org.poten.backend.clova.dto.response.QuestionDto;
 import org.poten.backend.clova.service.ClovaQuestionService;
+import org.poten.backend.global.jwt.JwtProvider;
+import org.poten.backend.user.entity.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.poten.backend.global.security.CustomUserDetails;
-import org.poten.backend.global.error.GlobalErrorCode;
-import org.poten.backend.global.exception.CustomException;
+import org.poten.backend.user.repository.UserRepository;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.List;
 import java.util.Map;
@@ -21,14 +21,29 @@ import java.util.Map;
 public class ClovaQuestionController {
 
     private final ClovaQuestionService clovaQuestionService;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
     @PostMapping("/question")
-    public List<QuestionDto> generateAndSaveQuestion(@RequestBody Map<String, String> request, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        if (customUserDetails == null) {
-            throw new CustomException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
-        }
+    public List<QuestionDto> generateAndSaveQuestion(
+        @RequestBody Map<String, String> request,
+        @RequestHeader(value = "Authorization", required = false) String authHeader) {
+
         String plainText = request.get("plainText");
         String type = request.get("type");
-        return clovaQuestionService.generateAndSaveQuestion(plainText, type, customUserDetails.getUser());
+        User user = null;
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtProvider.validateToken(token)) {
+                String loginId = jwtProvider.getLoginIdFromToken(token);
+                user = userRepository.findByLoginId(loginId)
+                    .orElseThrow(() -> new IllegalArgumentException("user not found"));
+            } else {
+                throw new IllegalArgumentException("Invalid token");
+            }
+        }
+
+        return clovaQuestionService.generateAndSaveQuestion(plainText, type, user);
     }
 }

--- a/src/main/java/org/poten/backend/clova/dto/request/ClovaRequest.java
+++ b/src/main/java/org/poten/backend/clova/dto/request/ClovaRequest.java
@@ -11,9 +11,9 @@ public class ClovaRequest {
     private List<Message> messages;
     private double topP = 0.8;
     private int topK = 0;
-    private int maxTokens = 500;
+    private int maxTokens = 2000;
     private double temperature = 0.3;
-    private double repetitionPenalty = 1.1;
+    private double repetitionPenalty = 1.0;
     private List<String> stop = List.of();
     private int seed = 0;
     private boolean includeAiFilters = true;

--- a/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
+++ b/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
@@ -1,16 +1,32 @@
 package org.poten.backend.clova.dto.response;
 
+import java.util.Collections;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.poten.backend.question.entity.Question;
 
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class QuestionDto {
+    private Long questionId;
     private String question;
     private String type;
     private List<String> options;
     private String answer;
     private String explanation;
+
+    public static QuestionDto from(Question question) {
+        return new QuestionDto(
+                question.getId(),
+                question.getQuestionText(),
+                question.getQuestionType(),
+                Collections.emptyList(),
+                question.getAnswer(),
+                question.getExplanation()
+        );
+    }
 }

--- a/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
+++ b/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
@@ -38,7 +38,8 @@ public class ClovaQuestionService {
 
     @Transactional
     public List<QuestionDto> generateAndSaveQuestion(String plainText, String type, User user) {
-        String requestBody = createClovaRequestBody(plainText, type);
+        String systemContent = (user != null) ? getMemberSystemContent() : getNonMemberSystemContent();
+        String requestBody = createClovaRequestBody(plainText, type, systemContent);
 
         Request request = new Request.Builder()
                 .url(clovaProperty.getUrl())
@@ -75,6 +76,7 @@ public class ClovaQuestionService {
     }
 
     private List<Question> saveQuestions(List<QuestionDto> questionDtos, User user) {
+        Boolean guset = (user == null);
         List<Question> questions = questionDtos.stream()
                 .map(questionDto -> Question.builder()
                         .questionText(questionDto.getQuestion())
@@ -82,19 +84,65 @@ public class ClovaQuestionService {
                         .questionType(questionDto.getType())
                         .explanation(questionDto.getExplanation())
                         .user(user)
+                        .guest(guset)
                         .build())
                 .collect(Collectors.toList());
         return questionRepository.saveAll(questions);
     }
 
-    private String createClovaRequestBody(String plainText, String type) {
-        Message systemMessage = new Message("system", List.of(new Content("text", getSystemContent())));
+    private String createClovaRequestBody(String plainText, String type, String systemContent) {
+        Message systemMessage = new Message("system", List.of(new Content("text", systemContent)));
         Message userMessage = new Message("user", List.of(new Content("text", "<입력으로 들어온 정리> " + plainText + " 문제 유형: <" + type + ">")));
         ClovaRequest clovaRequest = new ClovaRequest(List.of(systemMessage, userMessage));
         return new OkHttpJsonRequest(clovaRequest).convertRequestToString();
     }
 
-    private String getSystemContent() {
+    public String getMemberSystemContent() {
+        return """
+        [역할]
+        너는 사용자가 정리한 내용을 바탕으로만 문제를 생성하는 AI야.
+        지식 창작, 일반 상식, 부정확한 내용 추가는 절대 하지 마.
+
+        [규칙]
+        - 무조건 10개의 문제를 생성할 것. 7개 이하일 경우 실패로 간주합니다.
+        - 문제는 반드시 입력 내용 안에서만 만들 것
+        - 문제 유형은 반드시 다음 중 하나로만 제한할 것: MULTIPLE_CHOICE, SHORT_ANSWER, TRUE_FALSE
+        - 텍스트 지문에 포함되지 않은 내용은 퀴즈로 출제하지 않습니다.
+        - 모든 문제는 아래 구조와 동일한 JSON 형식으로 반환할 것
+        - 모든 문제 유형에서 다음 키 값을 항상 포함해야 함:
+          `question`, `type`, `options`, `answer`, `explanation`
+
+        객관식(MULTIPLE_CHOICE)
+        - `options`는 반드시 4개의 보기 항목 포함
+        - `answer`는 `options` 중 하나여야 함
+
+        단답형(SHORT_ANSWER) 또는 OX(TRUE_FALSE)
+        - `options`는 빈 배열 `[]`
+        - `answer`는 간결한 문자열
+        - `TRUE_FALSE`는 "TRUE" 또는 "FALSE"만 허용
+
+        모든 문제에는 `explanation` 필드를 포함
+        - 사용자가 정답을 이해할 수 있도록, AI가 간단히 핵심 개념을 요약하거나 정답의 이유를 1문장으로 설명
+        - 입력 내용 기반이어야 하며, 과도한 추측이나 새로운 지식 창작은 지양
+
+        ---
+
+        [출력 예시]
+        ```json
+        [
+          {
+            "question": "HTTP는 상태를 저장하지 않는 프로토콜이다.",
+            "type": "TRUE_FALSE",
+            "options": [],
+            "answer": "TRUE",
+            "explanation": "HTTP는 무상태(stateless) 프로토콜로, 각 요청은 독립적으로 처리된다."
+          }
+        ]
+        ```
+        """;
+    }
+
+    public String getNonMemberSystemContent() {
         return """
         [역할]
         너는 사용자가 정리한 내용을 바탕으로만 문제를 생성하는 AI야.

--- a/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
+++ b/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
@@ -64,15 +64,17 @@ public class ClovaQuestionService {
 
             List<QuestionDto> questionDtos = objectMapper.readValue(jsonContent, new com.fasterxml.jackson.core.type.TypeReference<List<QuestionDto>>() {});
 
-            saveQuestions(questionDtos, user);
+            List<Question> savedQuestions = saveQuestions(questionDtos, user);
 
-            return questionDtos;
+            return savedQuestions.stream()
+                    .map(QuestionDto::from)
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new ClovaQuestionServiceException(ClovaQuestionServiceErrorCode.CLOVA_API_ERROR);
         }
     }
 
-    private void saveQuestions(List<QuestionDto> questionDtos, User user) {
+    private List<Question> saveQuestions(List<QuestionDto> questionDtos, User user) {
         List<Question> questions = questionDtos.stream()
                 .map(questionDto -> Question.builder()
                         .questionText(questionDto.getQuestion())
@@ -82,7 +84,7 @@ public class ClovaQuestionService {
                         .user(user)
                         .build())
                 .collect(Collectors.toList());
-        questionRepository.saveAll(questions);
+        return questionRepository.saveAll(questions);
     }
 
     private String createClovaRequestBody(String plainText, String type) {

--- a/src/main/java/org/poten/backend/global/config/SecurityConfig.java
+++ b/src/main/java/org/poten/backend/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/user/signup",
                                 "api/user/login",
-                                "/oauth2/**"
+                                "/oauth2/**",
+                                "/api/v1/clova/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/poten/backend/global/infra/clova/OkHttpRequest.java
+++ b/src/main/java/org/poten/backend/global/infra/clova/OkHttpRequest.java
@@ -14,7 +14,11 @@ import java.io.IOException;
 @Slf4j
 public abstract class OkHttpRequest {
 
-    private static final OkHttpClient client = new OkHttpClient();
+    private static final OkHttpClient client = new OkHttpClient.Builder()
+        .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+        .writeTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+        .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS) // 응답 대기 시간
+        .build();
 
     public static Response createRequest(Request request) {
         StringBuilder logStringBuilder = new StringBuilder();

--- a/src/main/java/org/poten/backend/question/entity/Question.java
+++ b/src/main/java/org/poten/backend/question/entity/Question.java
@@ -38,8 +38,11 @@ public class Question extends BaseEntity {
     private String explanation;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true) // 비회원은 null
     private User user;
+
+    @Column(nullable = false)
+    private Boolean guest = false; //  비회원용 문제 여부
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SolveHistory> solveHistories = new ArrayList<>();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: Closes #13  (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

1. 비로그인 상태에서도 문제 생성(3개)
2. 로그인 상태에서 10문제 생성하도록 변경
3. api 반환값에 id 추가

## #️⃣ 테스트 결과

> 작업 내용 모두 테스트 하였습니다.


## #️⃣ 스크린샷 (선택)
<img width="738" height="580" alt="스크린샷 2025-08-04 오후 12 43 00" src="https://github.com/user-attachments/assets/3f469a58-cdb1-4ad7-ade5-f65fbe789f38" />
-> 비회원 상태에서의 문제 생성입니다.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요