### PR TITLE
feat(#12):비회원 채점 기능 추가

### DIFF
--- a/src/main/java/org/poten/backend/global/config/SecurityConfig.java
+++ b/src/main/java/org/poten/backend/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                                 "/api/user/signup",
                                 "api/user/login",
                                 "/oauth2/**",
+                                "/api/questions/*/guest-answer",
                                 "/api/v1/clova/**"
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/org/poten/backend/question/controller/QuizController.java
+++ b/src/main/java/org/poten/backend/question/controller/QuizController.java
@@ -36,5 +36,12 @@ public class QuizController {
 
         return quizService.submitAnswer(userId, questionId, req);
     }
+
+    @PostMapping("/{id}/guest-answer")
+    public AnswerResponse guestAnswer(@PathVariable("id") Long questionId,
+                                      @RequestBody AnswerRequest req) {
+        return quizService.submitAnswerWithoutSave(questionId, req);
+    }
+
 }
 

--- a/src/main/java/org/poten/backend/question/service/QuizService.java
+++ b/src/main/java/org/poten/backend/question/service/QuizService.java
@@ -46,6 +46,25 @@ public class QuizService {
         return res;
     }
 
+    /* 비회원 전용 로직 */
+    public AnswerResponse submitAnswerWithoutSave(Long questionId, AnswerRequest req) {
+        Question q = questionRepo.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("question not found: " + questionId));
+
+        String normalizedUser = normalize(req.getUserAnswer());
+        String normalizedAnswer = normalize(q.getAnswer());
+
+        boolean correct = normalizedUser.equalsIgnoreCase(normalizedAnswer);
+
+        AnswerResponse res = new AnswerResponse();
+        res.setCorrect(correct);
+        res.setCorrectAnswer(normalizedAnswer);
+        res.setExplanation(q.getExplanation());
+        res.setQuestionId(q.getId());
+        return res;
+    }
+
+
     private String normalize(String a) {
         if (a == null) return "";
         String s = a.trim().toUpperCase();


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #12 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 비회원인 경우에도 채점이 될 수 있도록 API를 추가 개발하였습니다.
- Question 엔티티에 guest 컬럼이 추가되었으며, 비회원일 경우 user_id가 null일 수 있도록 수정되었습니다.
- SecurityConfig에 해당 API permitAll 적용했습니다.

## #️⃣ 테스트 결과

- 비회원일 경우 토큰 없이 채점되는 것 테스트 완료 했습니다.

## #️⃣ 스크린샷 (선택)

<img width="1054" height="777" alt="image" src="https://github.com/user-attachments/assets/69e4d133-1789-4554-beaf-d735169ab91a" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요