### PR TITLE
feat(#18):아이디 중복 확인 추가

### DIFF
--- a/src/main/java/org/poten/backend/global/config/SecurityConfig.java
+++ b/src/main/java/org/poten/backend/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/user/signup",
                                 "api/user/login",
+                                "api/user/check-id",
                                 "/oauth2/**",
                                 "/api/questions/*/guest-answer",
                                 "/api/v1/clova/**"

--- a/src/main/java/org/poten/backend/user/controller/UserController.java
+++ b/src/main/java/org/poten/backend/user/controller/UserController.java
@@ -39,5 +39,12 @@ public class UserController {
         userService.delete(loginId);
         return ResponseEntity.ok("탈퇴 완료");
     }
+    @GetMapping("/check-id")
+    public ResponseEntity<Boolean> checkLoginIdDuplicate(@RequestParam String loginId) {
+        boolean isDuplicate = userService.checkLoginIdDuplicate(loginId);
+        return ResponseEntity.ok(isDuplicate);
+    }
+
+
 
 }

--- a/src/main/java/org/poten/backend/user/repository/UserRepository.java
+++ b/src/main/java/org/poten/backend/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+
 }

--- a/src/main/java/org/poten/backend/user/service/UserService.java
+++ b/src/main/java/org/poten/backend/user/service/UserService.java
@@ -18,4 +18,5 @@ public interface UserService {
 
     TokenRefreshResponseDto reissueAccessToken(TokenRefreshRequestDto requestDto);
 
+    boolean checkLoginIdDuplicate(String nickname);
 }

--- a/src/main/java/org/poten/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/org/poten/backend/user/service/UserServiceImpl.java
@@ -24,6 +24,11 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    public boolean checkLoginIdDuplicate(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
+
     @Override
     public void signup(UserSignupRequestDto requestDto) {
         if(userRepository.findByLoginId(requestDto.getLoginId()).isPresent()){


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #18 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용
****닉네임 중복 확인 XXXX**
- 아이디 중복 확인 입니다.
- 중복->true
- 중복x->false
## #️⃣ 테스트 결과

- 중복인 경우, 중복 아닌 경우 모두 테스트 완료입니다.

## #️⃣ 스크린샷 (선택)
<img width="1057" height="597" alt="image" src="https://github.com/user-attachments/assets/61650cd8-6e74-4a99-a7ec-d1ccb161d1b1" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요