### PR TITLE
Feat/#28 객관식 문제 제작이 가능하다.

### DIFF
--- a/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
+++ b/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
@@ -28,7 +28,7 @@ public class QuestionDto {
                 question.getId(),
                 question.getQuestionText(),
                 question.getQuestionType(),
-                Collections.emptyList(),
+                question.getOptions(),
                 question.getAnswer(),
                 question.getExplanation(),
                 question.getCreatedAt(),

--- a/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
+++ b/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
@@ -83,6 +83,7 @@ public class ClovaQuestionService {
                         .answer(questionDto.getAnswer())
                         .questionType(questionDto.getType())
                         .explanation(questionDto.getExplanation())
+                        .options(questionDto.getOptions())
                         .user(user)
                         .guest(guset)
                         .build())

--- a/src/main/java/org/poten/backend/question/entity/Question.java
+++ b/src/main/java/org/poten/backend/question/entity/Question.java
@@ -2,6 +2,7 @@ package org.poten.backend.question.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -36,6 +37,12 @@ public class Question extends BaseEntity {
 
     @Column(nullable = false)
     private String explanation;
+
+    @Builder.Default
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "question_options", joinColumns = @JoinColumn(name = "question_id"))
+    @Column(name = "option_text")
+    private List<String> options = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = true) // 비회원은 null


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #28` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- [X] api 요청에 문제 타입을 선택 할 수 있도록 수정
- [X] 객관식 타입의 문제 반환시 옵션(문제의 보기) 값 제공

## #️⃣ 테스트 결과
<img width="1896" height="1221" alt="스크린샷 2025-08-11 오후 1 15 23" src="https://github.com/user-attachments/assets/2cea8b79-d9f7-4560-8305-d00b22c66b1e" />


## #️⃣ 스크린샷 (선택)




## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요