### PR TITLE
feat(#30):type에 구애 받지 않는 채점 로직으로 수정

### DIFF
--- a/src/main/java/org/poten/backend/question/service/QuizService.java
+++ b/src/main/java/org/poten/backend/question/service/QuizService.java
@@ -25,22 +25,21 @@ public class QuizService {
         Question q = questionRepo.findById(questionId)
                 .orElseThrow(() -> new IllegalArgumentException("question not found: " + questionId));
 
-        String normalizedUser = normalize(req.getUserAnswer());
-        String normalizedAnswer = normalize(q.getAnswer());
 
-        boolean correct = normalizedUser.equalsIgnoreCase(normalizedAnswer);
+
+        boolean correct = isCorrect(q,req.getUserAnswer());
 
         SolveHistory h = new SolveHistory();
         h.setUser(userRepo.getReferenceById(userId));
         h.setQuestion(q);
         h.setIsTrue(correct);
-        h.setUser_answer(normalizedUser);
+        h.setUser_answer(req.getUserAnswer());
 
         historyRepo.save(h);
 
         AnswerResponse res = new AnswerResponse();
         res.setCorrect(correct);
-        res.setCorrectAnswer(normalizedAnswer);
+        res.setCorrectAnswer(q.getAnswer());
         res.setExplanation(q.getExplanation());
         res.setQuestionId(q.getId());
         return res;
@@ -51,25 +50,27 @@ public class QuizService {
         Question q = questionRepo.findById(questionId)
                 .orElseThrow(() -> new IllegalArgumentException("question not found: " + questionId));
 
-        String normalizedUser = normalize(req.getUserAnswer());
-        String normalizedAnswer = normalize(q.getAnswer());
 
-        boolean correct = normalizedUser.equalsIgnoreCase(normalizedAnswer);
+        boolean correct = isCorrect(q,req.getUserAnswer());
 
         AnswerResponse res = new AnswerResponse();
         res.setCorrect(correct);
-        res.setCorrectAnswer(normalizedAnswer);
+        res.setCorrectAnswer(q.getAnswer());
         res.setExplanation(q.getExplanation());
         res.setQuestionId(q.getId());
         return res;
     }
 
+    private boolean isCorrect(Question q, String userInputRaw){
+        String userAN = normalizeText(userInputRaw);
+        return userAN.equals(q.getAnswer());
 
-    private String normalize(String a) {
-        if (a == null) return "";
-        String s = a.trim().toUpperCase();
-        if ("O".equals(s) || "TRUE".equals(s))  return "TRUE";
-        if ("X".equals(s) || "FALSE".equals(s)) return "FALSE";
-        throw new IllegalArgumentException("answer must be O/X/TRUE/FALSE");
+    }
+
+
+
+    private String normalizeText(String a){
+        if(a== null) return "";
+        return a.trim().toUpperCase();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #30 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- OX, 객관식, 주관식에 구애 받지 않도록 채점 로직을 단순화하여 통일했습니다.

## #️⃣ 테스트 결과

- 비회원, 회원인 경우 모두 정상 기능합니다.

## #️⃣ 스크린샷 (선택)

<img width="1315" height="909" alt="image" src="https://github.com/user-attachments/assets/412631ca-5086-4dc1-b0a4-f5e4d3034278" />
<img width="1347" height="848" alt="image" src="https://github.com/user-attachments/assets/254e0e95-751b-4c43-a763-12e8993e68e2" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요