### PR TITLE
Feat/#32 문제 모아보기에서 유저의 최근 풀이 정보도 함께 반환한다.

### DIFF
--- a/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
+++ b/src/main/java/org/poten/backend/clova/dto/response/QuestionDto.java
@@ -1,13 +1,14 @@
 package org.poten.backend.clova.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.poten.backend.question.entity.Question;
-
-import java.util.List;
+import org.poten.backend.question.entity.SolveHistory;
 
 @Getter
 @NoArgsConstructor
@@ -21,9 +22,13 @@ public class QuestionDto {
     private String explanation;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private String latestSolveStatus;
 
+    public static QuestionDto from(Question question, Optional<SolveHistory> solveHistory) {
+        String status = solveHistory
+                .map(history -> history.getIsTrue() ? "CORRECT" : "INCORRECT")
+                .orElse("UNSOLVED");
 
-    public static QuestionDto from(Question question) {
         return new QuestionDto(
                 question.getId(),
                 question.getQuestionText(),
@@ -32,7 +37,8 @@ public class QuestionDto {
                 question.getAnswer(),
                 question.getExplanation(),
                 question.getCreatedAt(),
-                question.getUpdatedAt()
+                question.getUpdatedAt(),
+                status
         );
     }
 }

--- a/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
+++ b/src/main/java/org/poten/backend/clova/service/ClovaQuestionService.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.poten.backend.global.infra.clova.OkHttpRequest.createRequest;
@@ -68,7 +69,7 @@ public class ClovaQuestionService {
             List<Question> savedQuestions = saveQuestions(questionDtos, user);
 
             return savedQuestions.stream()
-                    .map(QuestionDto::from)
+                    .map(question -> QuestionDto.from(question, Optional.empty()))
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new ClovaQuestionServiceException(ClovaQuestionServiceErrorCode.CLOVA_API_ERROR);

--- a/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
@@ -1,12 +1,21 @@
 package org.poten.backend.question.repository;
 
+import org.poten.backend.question.entity.Question;
 import org.poten.backend.question.entity.SolveHistory;
+import org.poten.backend.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
     Page<SolveHistory> findByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
     boolean existsByUser_IdAndQuestion_Id(Long userId, Long questionId);
+
+    @Query("SELECT sh FROM SolveHistory sh WHERE sh.user = :user AND sh.question IN :questions AND sh.createdAt = (SELECT MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = sh.user AND sh2.question = sh.question)")
+    List<SolveHistory> findLatestSolveHistories(@Param("user") User user, @Param("questions") List<Question> questions);
 }
 

--- a/src/main/java/org/poten/backend/question/service/QuestionService.java
+++ b/src/main/java/org/poten/backend/question/service/QuestionService.java
@@ -6,7 +6,9 @@ import org.poten.backend.global.error.GlobalErrorCode;
 import org.poten.backend.global.exception.CustomException;
 import org.poten.backend.question.dto.response.QuestionListResponse;
 import org.poten.backend.question.entity.Question;
+import org.poten.backend.question.entity.SolveHistory;
 import org.poten.backend.question.repository.QuestionRepository;
+import org.poten.backend.question.repository.SolveHistoryRepository;
 import org.poten.backend.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,6 +26,7 @@ import java.util.stream.Collectors;
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+    private final SolveHistoryRepository solveHistoryRepository;
 
     public List<QuestionListResponse> findAllQuestion(User user) {
         if (user == null) {
@@ -29,11 +34,16 @@ public class QuestionService {
         }
 
         List<Question> questions = questionRepository.findByUser(user);
+        List<SolveHistory> latestSolveHistories = solveHistoryRepository.findLatestSolveHistories(user, questions);
+
+        Map<Question, SolveHistory> solveHistoryMap = latestSolveHistories.stream()
+                .collect(Collectors.toMap(SolveHistory::getQuestion, Function.identity()));
 
         Map<LocalDate, List<QuestionDto>> groupedByDate = questions.stream()
                 .collect(Collectors.groupingBy(
                         question -> question.getCreatedAt().toLocalDate(),
-                        Collectors.mapping(QuestionDto::from, Collectors.toList())
+                        Collectors.mapping(question -> QuestionDto.from(question, Optional.ofNullable(solveHistoryMap.get(question))),
+                                Collectors.toList())
                 ));
 
         return groupedByDate.entrySet().stream()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #32 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

> 문제 모아보기에서 유저의 최근 풀이 정보도 함께 반환한다.

## #️⃣ 테스트 결과

> 반환 여부 확인, 오답 문제 풀이 상황 가정하여 테스트하여 값이 올바르게 변경되는 것을 확인


## #️⃣ 스크린샷 (선택)
<img width="1740" height="1167" alt="스크린샷 2025-08-12 오전 12 34 04" src="https://github.com/user-attachments/assets/e05b9b30-7446-4771-978b-2e81f838ef35" />
<img width="1740" height="1167" alt="스크린샷 2025-08-12 오전 12 34 11" src="https://github.com/user-attachments/assets/ac6c87b1-38e7-45c0-8a7f-83b4c286946f" />
-> 오답 풀이를 하여 맞춘 경우 "latestSolveStatus" 값이 변경된 것을 확인 가능


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요