### PR TITLE
feat(#34): 오답 문제 조회(날짜별)추가

### DIFF
--- a/src/main/java/org/poten/backend/question/controller/QuestionController.java
+++ b/src/main/java/org/poten/backend/question/controller/QuestionController.java
@@ -28,4 +28,14 @@ public class QuestionController {
         }
         return ResponseEntity.ok(questionService.findAllQuestion(customUserDetails.getUser()));
     }
+
+    @GetMapping("/wrong")
+    public ResponseEntity<List<QuestionListResponse>> findLatestIncorrectByCreatedDate(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) throw new CustomException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
+        return ResponseEntity.ok(
+                questionService.findLatestIncorrectByCreatedDate(userDetails.getUser())
+        );
+    }
+
 }

--- a/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/poten/backend/question/repository/SolveHistoryRepository.java
@@ -17,5 +17,13 @@ public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long
 
     @Query("SELECT sh FROM SolveHistory sh WHERE sh.user = :user AND sh.question IN :questions AND sh.createdAt = (SELECT MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = sh.user AND sh2.question = sh.question)")
     List<SolveHistory> findLatestSolveHistories(@Param("user") User user, @Param("questions") List<Question> questions);
+
+    @Query("""
+    SELECT sh FROM SolveHistory sh WHERE sh.user = :user AND sh.question IN :questions AND sh.createdAt = (SELECT MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = sh.user AND sh2.question = sh.question)
+    AND sh.isTrue = false
+    """)
+    List<SolveHistory> findLatestIncorrectSolveHistories(@Param("user") User user, @Param("questions") List<Question> questions);
+
+
 }
 

--- a/src/main/java/org/poten/backend/question/service/QuestionService.java
+++ b/src/main/java/org/poten/backend/question/service/QuestionService.java
@@ -53,4 +53,40 @@ public class QuestionService {
                         .build())
                 .collect(Collectors.toList());
     }
+    @Transactional(readOnly = true)
+    public List<QuestionListResponse> findLatestIncorrectByCreatedDate(User user) {
+        if (user == null) throw new CustomException(GlobalErrorCode.USER_NOT_FOUND);
+
+
+        List<Question> questions = questionRepository.findByUser(user);
+
+
+        List<SolveHistory> latestIncorrect = solveHistoryRepository
+                .findLatestIncorrectSolveHistories(user, questions);
+
+        Map<Question, SolveHistory> shMap = latestIncorrect.stream()
+                .collect(Collectors.toMap(SolveHistory::getQuestion, Function.identity()));
+
+
+        Map<LocalDate, List<Question>> grouped = questions.stream()
+                .filter(shMap::containsKey) // 최신 풀이가 오답인 문제만
+                .collect(Collectors.groupingBy(q -> q.getCreatedAt().toLocalDate()));
+
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    List<QuestionDto> dtos = entry.getValue().stream()
+                            .sorted((a, b) -> shMap.get(b).getCreatedAt()
+                                    .compareTo(shMap.get(a).getCreatedAt()))
+                            .map(q -> QuestionDto.from(q, Optional.of(shMap.get(q))))
+                            .collect(Collectors.toList());
+                    return QuestionListResponse.builder()
+                            .date(entry.getKey())
+                            .questions(dtos)
+                            .build();
+                })
+                .sorted((a, b) -> b.getDate().compareTo(a.getDate()))
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION


## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #34 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 유저의 오답 문제만을 날짜별로 조회할 수 있는 기능을 추가하였습니다. 
## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등


## #️⃣ 스크린샷 (선택)

<img width="1378" height="1122" alt="image" src="https://github.com/user-attachments/assets/a4d4c6f3-3b65-468d-8d2b-5998df6ba29f" />

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요