### PR TITLE
FEAT(#40): 문제의 주제를 수정 api 추가

### DIFF
--- a/src/main/java/org/poten/backend/question/controller/QuestionController.java
+++ b/src/main/java/org/poten/backend/question/controller/QuestionController.java
@@ -5,12 +5,17 @@ import org.poten.backend.global.error.GlobalErrorCode;
 import org.poten.backend.global.exception.CustomException;
 import org.poten.backend.question.dto.response.QuestionListResponse;
 import org.poten.backend.question.service.QuestionService;
+import org.poten.backend.question.service.QuestionTopicService;
 import org.poten.backend.global.security.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import org.poten.backend.question.dto.request.TopicUpdateRequestDto;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -20,6 +25,7 @@ import java.util.List;
 public class QuestionController {
 
     private final QuestionService questionService;
+    private final QuestionTopicService questionTopicService;
 
     @GetMapping
     public ResponseEntity<List<QuestionListResponse>> findAllQuestion(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -38,4 +44,9 @@ public class QuestionController {
         );
     }
 
+    @PatchMapping("/topic")
+    public ResponseEntity<Void> updateQuestionTopic(@RequestBody TopicUpdateRequestDto requestDto) {
+        questionTopicService.updateQuestionTopic(requestDto);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/org/poten/backend/question/dto/request/TopicUpdateRequestDto.java
+++ b/src/main/java/org/poten/backend/question/dto/request/TopicUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package org.poten.backend.question.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TopicUpdateRequestDto {
+    private String topic;
+    private List<Long> questionIds;
+}

--- a/src/main/java/org/poten/backend/question/service/QuestionTopicService.java
+++ b/src/main/java/org/poten/backend/question/service/QuestionTopicService.java
@@ -1,0 +1,50 @@
+package org.poten.backend.question.service;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.poten.backend.global.error.ErrorCode;
+import org.poten.backend.global.exception.CustomException;
+import org.poten.backend.question.dto.request.TopicUpdateRequestDto;
+import org.poten.backend.question.entity.Question;
+import org.poten.backend.question.repository.QuestionRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionTopicService {
+
+    private final QuestionRepository questionRepository;
+
+    @Transactional
+    public void updateQuestionTopic(TopicUpdateRequestDto requestDto) {
+        List<Long> requestedIds = requestDto.getQuestionIds();
+        List<Question> foundQuestions = questionRepository.findAllById(requestedIds);
+        if (foundQuestions.size() != requestedIds.size()) {
+            throw new QuestionTopicServiceException(QuestionTopicErrorCode.QUESTION_NOT_FOUND);
+        }
+        for (Question question : foundQuestions) {
+            question.setTopic(requestDto.getTopic());
+        }
+        questionRepository.saveAll(foundQuestions);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum QuestionTopicErrorCode implements ErrorCode {
+        QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "존재하지 않는 문제입니다.");
+
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+    }
+
+    public static class QuestionTopicServiceException extends CustomException {
+        public QuestionTopicServiceException(ErrorCode errorCode) {
+            super(errorCode);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #40 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

> 문제의 주제를 수정 할 수 있다.

## #️⃣ 테스트 결과

<img width="1392" height="1167" alt="스크린샷 2025-08-15 오전 2 10 54" src="https://github.com/user-attachments/assets/71160296-faab-4f27-9bd9-04f775f78eb3" />
<img width="1392" height="1167" alt="스크린샷 2025-08-15 오전 2 11 02" src="https://github.com/user-attachments/assets/70586ff0-e311-43fd-abc0-9dbf0dbe5e2b" />
-> 존재하지 않은 문제인 경우 예외 발생하게 하였습니다.


## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요