### PR TITLE
feat(#42): 주제별 오답 조회 추가

### DIFF
--- a/src/main/java/org/poten/backend/question/controller/QuestionController.java
+++ b/src/main/java/org/poten/backend/question/controller/QuestionController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.poten.backend.global.error.GlobalErrorCode;
 import org.poten.backend.global.exception.CustomException;
 import org.poten.backend.question.dto.response.QuestionListResponse;
+import org.poten.backend.question.dto.response.QuestionTopicResponse;
 import org.poten.backend.question.service.QuestionService;
 import org.poten.backend.question.service.QuestionTopicService;
 import org.poten.backend.global.security.CustomUserDetails;
@@ -49,4 +50,14 @@ public class QuestionController {
         questionTopicService.updateQuestionTopic(requestDto);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/wrong/topic")
+    public ResponseEntity<List<QuestionTopicResponse>> findLatestIncorrectByTopic(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) throw new CustomException(GlobalErrorCode.REFRESH_TOKEN_MISMATCH);
+        return ResponseEntity.ok(
+                questionService.findLatestIncorrectByTopic(userDetails.getUser())
+        );
+    }
+
 }

--- a/src/main/java/org/poten/backend/question/dto/response/QuestionTopicResponse.java
+++ b/src/main/java/org/poten/backend/question/dto/response/QuestionTopicResponse.java
@@ -1,0 +1,18 @@
+package org.poten.backend.question.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.poten.backend.clova.dto.response.QuestionDto;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionTopicResponse {
+    private String topic;
+    private List<QuestionDto> questions;
+}

--- a/src/main/java/org/poten/backend/question/service/QuestionService.java
+++ b/src/main/java/org/poten/backend/question/service/QuestionService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.poten.backend.global.error.GlobalErrorCode;
 import org.poten.backend.global.exception.CustomException;
 import org.poten.backend.question.dto.response.QuestionListResponse;
+import org.poten.backend.question.dto.response.QuestionTopicResponse;
 import org.poten.backend.question.entity.Question;
 import org.poten.backend.question.entity.SolveHistory;
 import org.poten.backend.question.repository.QuestionRepository;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,5 +90,40 @@ public class QuestionService {
                 .sorted((a, b) -> b.getDate().compareTo(a.getDate()))
                 .collect(Collectors.toList());
     }
+
+
+    @Transactional(readOnly = true)
+    public List<QuestionTopicResponse> findLatestIncorrectByTopic(User user) {
+        if (user == null) throw new CustomException(GlobalErrorCode.USER_NOT_FOUND);
+
+        List<Question> questions = questionRepository.findByUser(user);
+
+        List<SolveHistory> latestIncorrect = solveHistoryRepository
+                .findLatestIncorrectSolveHistories(user, questions);
+
+        Map<Question, SolveHistory> shMap = latestIncorrect.stream()
+                .collect(Collectors.toMap(SolveHistory::getQuestion, Function.identity()));
+
+
+        Map<String, List<Question>> grouped = questions.stream()
+                .filter(shMap::containsKey)
+                .collect(Collectors.groupingBy(q -> q.getTopic() == null ? "미지정" : q.getTopic()));
+
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    List<QuestionDto> dtos = entry.getValue().stream()
+                            .sorted((a, b) -> shMap.get(b).getCreatedAt()
+                                    .compareTo(shMap.get(a).getCreatedAt()))
+                            .map(q -> QuestionDto.from(q, Optional.of(shMap.get(q))))
+                            .collect(Collectors.toList());
+                    return QuestionTopicResponse.builder()
+                            .topic(entry.getKey())
+                            .questions(dtos)
+                            .build();
+                })
+                .sorted(Comparator.comparing(QuestionTopicResponse::getTopic))
+                .collect(Collectors.toList());
+    }
+
 
 }


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> 이 PR이 해결하는 이슈: `Closes #42 ` (병합 시 자동으로 이슈 닫힘)

## #️⃣ 작업 내용

- 주제별 오답 조회 기능을 추가합니다. 
- 현재 topic 값이 null 일 경우 -> "미지정"으로 분류됩니다.
- 
## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등


## #️⃣ 스크린샷 (선택)

<img width="1348" height="1064" alt="image" src="https://github.com/user-attachments/assets/2a05b2b3-91c6-4205-9abd-4baa7e9a6562" />

<img width="1373" height="1128" alt="image" src="https://github.com/user-attachments/assets/5c7d5da2-508e-4bf5-941b-be222c08a27b" />


## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요